### PR TITLE
Update documentation now that Saige >1.0 is available on Bioconda

### DIFF
--- a/docs/Installation_bioconda.md
+++ b/docs/Installation_bioconda.md
@@ -1,22 +1,25 @@
 ---
 layout: default
-title: Bioconda (Not activated)
+title: Bioconda
 nav_order: 4
 description: "Just the Docs is a responsive Jekyll theme with built-in search that is easily customizable and hosted on GitHub Pages."
 parent: Installation
 ---
 
-###  Install SAIGE from bioconda (Not current version)
+###  Install SAIGE from bioconda
 
-#### Warning: please do not use this bioconda version for bgen input. We are working on the issue.
 ![r-saige](https://anaconda.org/bioconda/r-saige/badges/version.svg)
 ![latest_update](https://anaconda.org/bioconda/r-saige/badges/latest_release_date.svg)
 
-To install saige from conda simply create environment with latest version of R and saige:
+Recent versions of SAIGE are distributed through bioconda with exclusively linux support. Mac OS support may be possible through other installation methods.
+
+To install saige from bioconda simply create environment with latest version of R and saige:
 ```
-conda create -n saige -c conda-forge -c bioconda "r-base>=4.0" r-saige
+conda create -n saige -c conda-forge -c bioconda r-saige
 conda activate saige
 ```
+
+The installation will place the scripts in `extdata/` into your conda environment's PATH.
 
 More info on [r-saige conda package](https://anaconda.org/bioconda/r-saige) and available versions can be found in the [issue #272](https://github.com/weizhouUMICH/SAIGE/issues/272).
 


### PR DESCRIPTION
Update documentation now that bioconda has been updated to a newer version.

If tags and releases are created on the main SAIGE repository, BiocondaBot should be able to automatically keep the Bioconda releases up to date. 1.1.9 is delayed because bioconda-recipes is currently suffering from a continuous integration failure.